### PR TITLE
use workspace to persist doc archive to release job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,10 @@ jobs:
           path: .build/reports/
       - store_artifacts:
           path: .build/reports/
+      - persist_to_workspace:
+          root: .
+          paths:
+            - SwiftHooks.doccarchive
 
   release:
     docker:
@@ -53,6 +57,9 @@ jobs:
 
     steps:
       - checkout
+      - attach_workspace:
+          at: /tmp/workspace
+      - run: cp -r /tmp/workspace/SwiftHooks.doccarchive .
       - run: 
           name: Git Config
           command: |


### PR DESCRIPTION
<!-- PR Template
Thank you for contributing! Please read through the following **before** opening your PR.
* Verify you have read the Contribution Guidelines in the README
-->

# What Changed

Added workspace persistence to share built `.doccarchive` to release job

## Why

Otherwise it doesn't exist to push to gh-pages

Todo:

- [ ] Add tests
- [ ] Add docs
- [ ] Add release notes




<!-- GITHUB_RELEASE PR BODY: canary-version -->
📦 Published PR as canary version: <code>0.0.4--canary.3.38</code>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
