### PR TITLE
set base path for docs to work with github pages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,10 +38,9 @@ jobs:
               --fallback-display-name SwiftHooks \
               --fallback-bundle-identifier com.intuit.hooks \
               --additional-symbol-graph-dir .build/swift-docc-symbol-graphs \
-              --output-path SwiftHooks.doccarchive \
-              --hosting-base-path swift-hooks
+              --output-path SwiftHooks.doccarchive
 
-            swift run docc process-archive transform-for-static-hosting SwiftHooks.doccarchive
+            swift run docc process-archive transform-for-static-hosting --hosting-base-path swift-hooks SwiftHooks.doccarchive
       - store_test_results:
           path: .build/reports/
       - store_artifacts:

--- a/docs.sh
+++ b/docs.sh
@@ -4,7 +4,6 @@ swift run docc convert Sources/SwiftHooks/Documentation.docc \
   --fallback-display-name SwiftHooks \
   --fallback-bundle-identifier com.intuit.hooks \
   --additional-symbol-graph-dir .build/swift-docc-symbol-graphs \
-  --output-path SwiftHooks.doccarchive \
-  --hosting-base-path swift-hooks
+  --output-path SwiftHooks.doccarchive
 
-swift run docc process-archive transform-for-static-hosting SwiftHooks.doccarchive
+swift run docc process-archive transform-for-static-hosting --hosting-base-path swift-hooks SwiftHooks.doccarchive


### PR DESCRIPTION
<!-- PR Template
Thank you for contributing! Please read through the following **before** opening your PR.
* Verify you have read the Contribution Guidelines in the README
-->

# What Changed

Moved `--hosting-base-path` to the `process-archive` command

## Why

The documentation on how to use DocC is not clear on how to generate docs for static hosting, this should resolve the resource problem

Todo:

- [ ] Add tests
- [ ] Add docs
- [ ] Add release notes

# Release Notes


<!-- GITHUB_RELEASE PR BODY: canary-version -->
📦 Published PR as canary version: <code>0.0.5--canary.4.44</code>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
