### PR TITLE
Enable tvOS and watchOS support in Package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,9 @@ let package = Package(
     name: "SwiftHooks",
     platforms: [
         .iOS(.v13),
-        .macOS(.v10_15)
+        .macOS(.v10_15),
+        .tvOS(.v13),
+        .watchOS(.v6)
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.

--- a/SwiftHooks.podspec
+++ b/SwiftHooks.podspec
@@ -15,6 +15,9 @@ asynchronous
   s.source           = { :git => 'https://github.com/intuit/swift-hooks.git', :tag => s.version.to_s }
 
   s.ios.deployment_target = '13.0'
+  s.macos.deployment_target = '10.15'
+  s.tvos.deployment_target = '13.0'
+  s.watchos.deployment_target = '6.0'
 
   s.source_files = ['Sources/SwiftHooks/**/*.swift']
   s.exclude_files = ['**/*.docc/**/*']


### PR DESCRIPTION
<!-- PR Template
Thank you for contributing! Please read through the following **before** opening your PR.
* Verify you have read the Contribution Guidelines in the README
-->

# What Changed

Enable tvOS and watchOS support for Package.swift
Enable macOS, tvOS and watchOS in podspec

## Why

Works on all platforms

Todo:

- [ ] Add tests
- [ ] Add docs
- [ ] Add release notes

<!-- GITHUB_RELEASE PR BODY: canary-version -->
📦 Published PR as canary version: <code>0.0.6--canary.6.62</code>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
