### PR TITLE
Add support for untapping hooks

### DIFF
--- a/Sources/SwiftHooks/Documentation.docc/Resources/Untapping/UntapGeneratedId.swift
+++ b/Sources/SwiftHooks/Documentation.docc/Resources/Untapping/UntapGeneratedId.swift
@@ -1,0 +1,9 @@
+let someHook = SyncHook<Int>()
+
+let id: String? = someHook.tap(name: "Example") { value in
+    print(value)
+}
+
+/// `id` will be ``nil`` if the tap was rejected by a register interceptor
+
+id.map { someHook.untap($0) }

--- a/Sources/SwiftHooks/Documentation.docc/Resources/Untapping/UntapSuppliedId.swift
+++ b/Sources/SwiftHooks/Documentation.docc/Resources/Untapping/UntapSuppliedId.swift
@@ -1,0 +1,11 @@
+let someHook = SyncHook<Int>()
+let specificId = UUID().uuidString
+let id: String? = someHook.tap(name: "Example", id: specificId) { value in
+    print(value)
+}
+
+/// `id` will be ``nil`` if the tap was rejected by a register interceptor
+
+id.map { someHook.untap($0) }
+// or use the ID directly
+someHook.untap(specificId)

--- a/Sources/SwiftHooks/Documentation.docc/Untapping.tutorial
+++ b/Sources/SwiftHooks/Documentation.docc/Untapping.tutorial
@@ -1,0 +1,33 @@
+@Tutorial(time: 2) {
+    @Intro(title: "Untapping") {
+        All hooks have the ability to remove taps by calling `untap(_:)`.
+    }
+    
+    @Section(title: "Untapping Generated IDs") {
+        @ContentAndMedia {
+            IDs are generated automatically automatically if omitted.
+        }
+        
+        @Steps {            
+            @Step {
+                All `tap` calls will return an ID to untap with. The id can be `nil` if a register interceptor rejected the tap.
+                
+                @Code(name: "Untap.swift", file: UntapGeneratedId.swift)
+            }
+        }
+    }
+        
+    @Section(title: "Untapping Supplied IDs") {
+        @ContentAndMedia {
+            IDs can be supplied to any `tap` call to use a specific ID. Tapping a hook with the same ID more than once will only retain the most recent tap.
+        }
+        
+        @Steps {            
+            @Step {
+                All `tap` calls will return an ID to untap with. The id can be `nil` if a register interceptor rejected the tap.
+                
+                @Code(name: "Untap.swift", file: UntapSuppliedId.swift)
+            }
+        }
+    }
+}

--- a/Sources/SwiftHooks/Documentation.docc/User Guide.tutorial
+++ b/Sources/SwiftHooks/Documentation.docc/User Guide.tutorial
@@ -36,6 +36,12 @@
             
             @TutorialReference(tutorial: "doc:HookContextGuide")
         }
+        @Chapter(name: "Untapping") {
+            Advanced usage of SwiftHooks may see the need to remove taps under some circumstances.
+    <!--        @Image(source: <#file#>, alt: "<#accessible description#>")-->
+            
+            @TutorialReference(tutorial: "doc:Untapping")
+        }
     }
     
     @Resources {

--- a/Tests/HooksTests/AsyncSeriesHookTests.swift
+++ b/Tests/HooksTests/AsyncSeriesHookTests.swift
@@ -23,6 +23,152 @@ class AsyncSeriesHookTests: XCTestCase {
         wait(for: [expectation1, expectation2], timeout: 5)
     }
 
+    func testAsyncSeriesHookUntapGeneratedId() async {
+        let expectation1 = XCTestExpectation()
+        let expectation2 = XCTestExpectation()
+        expectation2.expectedFulfillmentCount = 2
+        let hook = AsyncSeriesHook<Int>()
+
+        let id = hook.tapAsync(name: "1") { val in
+            XCTAssertEqual(val, 2)
+            try? await Task.sleep(seconds: 1)
+            expectation1.fulfill()
+        }
+
+        hook.tap(name: "2") { val in
+            XCTAssertEqual(val, 2)
+            expectation2.fulfill()
+        }
+
+        await hook.call(2)
+        id.map { hook.untap($0) }
+        await hook.call(2)
+
+        wait(for: [expectation1, expectation2], timeout: 5)
+    }
+
+    func testAsyncSeriesHookUntapSuppliedId() async {
+        let expectation1 = XCTestExpectation()
+        let expectation2 = XCTestExpectation()
+        expectation2.expectedFulfillmentCount = 2
+        let hook = AsyncSeriesHook<Int>()
+
+        hook.tapAsync(name: "1", id: "test") { val in
+            XCTAssertEqual(val, 2)
+            try? await Task.sleep(seconds: 1)
+            expectation1.fulfill()
+        }
+
+        hook.tap(name: "2") { val in
+            XCTAssertEqual(val, 2)
+            expectation2.fulfill()
+        }
+
+        await hook.call(2)
+        hook.untap("test")
+        await hook.call(2)
+
+        wait(for: [expectation1, expectation2], timeout: 5)
+    }
+
+    func testAsyncSeriesHookUntapSuppliedIdSyncTap() async {
+        let expectation1 = XCTestExpectation()
+        let expectation2 = XCTestExpectation()
+        expectation2.expectedFulfillmentCount = 2
+        let hook = AsyncSeriesHook<Int>()
+
+        hook.tap(name: "1", id: "test") { val in
+            XCTAssertEqual(val, 2)
+            expectation1.fulfill()
+        }
+
+        hook.tap(name: "2") { val in
+            XCTAssertEqual(val, 2)
+            expectation2.fulfill()
+        }
+
+        await hook.call(2)
+        hook.untap("test")
+        await hook.call(2)
+
+        wait(for: [expectation1, expectation2], timeout: 5)
+    }
+
+    func testAsyncSeriesHookUntapSuppliedIdSyncTapWithContext() async {
+        let expectation1 = XCTestExpectation()
+        let expectation2 = XCTestExpectation()
+        expectation2.expectedFulfillmentCount = 2
+        let hook = AsyncSeriesHook<Int>()
+
+        hook.tap(name: "1", id: "test") { (_, val) in
+            XCTAssertEqual(val, 2)
+            expectation1.fulfill()
+        }
+
+        hook.tap(name: "2") { val in
+            XCTAssertEqual(val, 2)
+            expectation2.fulfill()
+        }
+
+        await hook.call(2)
+        hook.untap("test")
+        await hook.call(2)
+
+        wait(for: [expectation1, expectation2], timeout: 5)
+    }
+
+    func testAsyncSeriesHookUntapSuppliedIdWithContext() async {
+        let expectation1 = XCTestExpectation()
+        let expectation2 = XCTestExpectation()
+        expectation2.expectedFulfillmentCount = 2
+        let hook = AsyncSeriesHook<Int>()
+
+        hook.tapAsync(name: "1", id: "test") { (_, val) in
+            XCTAssertEqual(val, 2)
+            try? await Task.sleep(seconds: 1)
+            expectation1.fulfill()
+        }
+
+        hook.tap(name: "2") { val in
+            XCTAssertEqual(val, 2)
+            expectation2.fulfill()
+        }
+
+        await hook.call(2)
+        hook.untap("test")
+        await hook.call(2)
+
+        wait(for: [expectation1, expectation2], timeout: 5)
+    }
+
+    func testAsyncSeriesHookRegisterInterceptorRejection() async {
+        let expectation1 = XCTestExpectation()
+        expectation1.isInverted = true
+        let expectation2 = XCTestExpectation()
+        let hook = AsyncSeriesHook<Int>()
+
+        hook.interceptRegister { info in
+            guard info.name == "1" else { return info }
+            return nil
+        }
+
+        let id = hook.tapAsync(name: "1") { _ in
+            try? await Task.sleep(seconds: 1)
+            expectation1.fulfill()
+        }
+
+        XCTAssertNil(id)
+
+        hook.tap(name: "2") { val in
+            XCTAssertEqual(val, 2)
+            expectation2.fulfill()
+        }
+
+        await hook.call(2)
+
+        wait(for: [expectation1, expectation2], timeout: 5)
+    }
+
     func testRegisterInterceptors() async {
         let hook = AsyncSeriesHook<Int>()
         let registerExpectation = XCTestExpectation()

--- a/Tests/HooksTests/SyncHookTests.swift
+++ b/Tests/HooksTests/SyncHookTests.swift
@@ -31,4 +31,89 @@ class SyncHookTests: XCTestCase {
 
         wait(for: [expected], timeout: 1)
     }
+
+    func testUntappingGeneratedId() {
+        let expectation1 = XCTestExpectation()
+        let expectation2 = XCTestExpectation()
+        expectation2.expectedFulfillmentCount = 2
+        let hook = SyncHook<Int>()
+
+        let id = hook.tap(name: "1") { _ in
+            expectation1.fulfill()
+        }
+
+        hook.tap(name: "2") { _ in
+            expectation2.fulfill()
+        }
+
+        hook.call(0)
+        id.map { hook.untap($0) }
+        hook.call(1)
+        wait(for: [expectation1, expectation2], timeout: 1)
+    }
+
+    func testUntappingSuppliedId() {
+        let expectation1 = XCTestExpectation()
+        let expectation2 = XCTestExpectation()
+        expectation2.expectedFulfillmentCount = 2
+        let hook = SyncHook<Int>()
+
+        hook.tap(name: "1", id: "test") { _ in
+            expectation1.fulfill()
+        }
+
+        hook.tap(name: "2") { _ in
+            expectation2.fulfill()
+        }
+
+        hook.call(0)
+        hook.untap("test")
+        hook.call(1)
+        wait(for: [expectation1, expectation2], timeout: 1)
+    }
+
+    func testUntappingSuppliedIdWithContext() {
+        let expectation1 = XCTestExpectation()
+        let expectation2 = XCTestExpectation()
+        expectation2.expectedFulfillmentCount = 2
+        let hook = SyncHook<Int>()
+
+        hook.tap(name: "1", id: "test") { (_, _) in
+            expectation1.fulfill()
+        }
+
+        hook.tap(name: "2") { _ in
+            expectation2.fulfill()
+        }
+
+        hook.call(0)
+        hook.untap("test")
+        hook.call(1)
+        wait(for: [expectation1, expectation2], timeout: 1)
+    }
+
+    func testRegisterInterceptRejection() {
+        let expectation1 = XCTestExpectation(description: "hook 1 called")
+        expectation1.isInverted = true
+        let expectation2 = XCTestExpectation(description: "hook 2 called")
+        let hook = SyncHook<Int>()
+
+        hook.interceptRegister { info in
+            guard info.name == "1" else { return info }
+            return nil
+        }
+
+        let id = hook.tap(name: "1", id: "test") { _ in
+            expectation1.fulfill()
+        }
+
+        XCTAssertNil(id)
+
+        hook.tap(name: "2") { _ in
+            expectation2.fulfill()
+        }
+
+        hook.call(0)
+        wait(for: [expectation1, expectation2], timeout: 1)
+    }
 }


### PR DESCRIPTION
<!-- PR Template
Thank you for contributing! Please read through the following **before** opening your PR.
* Verify you have read the Contribution Guidelines in the README
-->

# What Changed

Adds an `untap(_:)` method to hooks, and has all `tap` methods return an ID that can be used to untap.

## Why

To prevent memory leaks, or just allow the ability for deregistering under certain circumstances may be necessary

Todo:

- [x] Add tests
- [x] Add docs
- [x] Add release notes

# Release Notes

Adds an `untap(_:)` method to hooks, and has all `tap` methods return an ID that can be used to untap.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
📦 Published PR as canary version: <code>0.1.0--canary.10.85</code>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
