### PR TITLE
reduce resource_class for circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2
 jobs:
   build:
+    resource_class: small
     docker:
       - image: hborawski/swift-docc-docker:sha-fa2a2c1
 


### PR DESCRIPTION
<!-- PR Template
Thank you for contributing! Please read through the following **before** opening your PR.
* Verify you have read the Contribution Guidelines in the README
-->

# What Changed

Reduced resource class to `small` instead of the default `large`

## Why

No need for a large, builds are short anyway

Todo:

- [ ] Add tests
- [ ] Add docs
- [ ] Add release notes


