### PR TITLE
add an additional exclusion for files

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
-        .target(name: "SwiftHooks"),
+        .target(name: "SwiftHooks", exclude: ["Documentation.docc"]),
         .target(name: "ExampleLibrary", dependencies: ["SwiftHooks"]),
         .testTarget(name: "HooksTests", dependencies: ["SwiftHooks"]),
         .testTarget(name: "ExampleLibraryTests", dependencies: ["ExampleLibrary"]),

--- a/SwiftHooks.podspec
+++ b/SwiftHooks.podspec
@@ -20,5 +20,5 @@ asynchronous
   s.watchos.deployment_target = '6.0'
 
   s.source_files = ['Sources/SwiftHooks/**/*.swift']
-  s.exclude_files = ['**/*.docc/**/*']
+  s.exclude_files = ['**/*.docc/**/*', '**/*.swiftdoc']
 end


### PR DESCRIPTION
<!-- PR Template
Thank you for contributing! Please read through the following **before** opening your PR.
* Verify you have read the Contribution Guidelines in the README
-->

# What Changed

- Exclude `.swiftdoc` files from the pod
- Exclude `Documentation.docc` from the SPM target

## Why

- Consumption through bazel and the cocoapods-bazel was failing to copy a swiftdoc file in Xcode 13.3+

Todo:

- [ ] Add tests
- [ ] Add docs
- [ ] Add release notes

# Release Notes


<!-- GITHUB_RELEASE PR BODY: canary-version -->
📦 Published PR as canary version: <code>0.1.1--canary.12.95</code>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
